### PR TITLE
Re-implement Link State Acknowledge to reflect OSPFv2 LSA and header format

### DIFF
--- a/examples/ospf-four-nodes.cc
+++ b/examples/ospf-four-nodes.cc
@@ -52,7 +52,7 @@ NS_LOG_COMPONENT_DEFINE("OspfFourNode");
 
 Ipv4Address ospfHelloAddress("224.0.0.5");
 
-const uint32_t SIM_SECONDS = 20;
+const uint32_t SIM_SECONDS = 100;
 
 void SetLinkDown(Ptr<NetDevice> nd) {
     Ptr<RateErrorModel> pem = CreateObject<RateErrorModel> ();

--- a/examples/ospf-two-nodes.cc
+++ b/examples/ospf-two-nodes.cc
@@ -52,7 +52,7 @@ NS_LOG_COMPONENT_DEFINE("OspfTwoNode");
 
 Ipv4Address ospfHelloAddress("224.0.0.5");
 
-const uint32_t SIM_SECONDS = 20;
+const uint32_t SIM_SECONDS = 100;
 
 int
 main(int argc, char* argv[])

--- a/helper/ospf-packet-helper.h
+++ b/helper/ospf-packet-helper.h
@@ -199,7 +199,7 @@ ConstructLSUPacket(Ipv4Address routerId, uint32_t areaId, uint16_t seqNum, uint1
 Ptr<Packet>
 ConstructLSAckPacket(Ipv4Address routerId, uint32_t areaId, std::vector<LsaHeader> lsaHeaders) {
     // Create a packet with the payload and the OSPF header
-    Ptr<Packet> lsAckPayload = Create<ns3::Packet>();
+    Ptr<Packet> lsAckPayload = Create<Packet>();
 
     // Fill in the lsaHeader
     for (LsaHeader lsaHeader : lsaHeaders) {
@@ -209,7 +209,7 @@ ConstructLSAckPacket(Ipv4Address routerId, uint32_t areaId, std::vector<LsaHeade
     // Add OSPF header
     OspfHeader ospfHeader;
     ospfHeader.SetType(OspfHeader::OspfType::OspfLSAck);
-    ospfHeader.SetPayloadSize(lsAckPayload->GetSerializedSize());
+    ospfHeader.SetPayloadSize(lsAckPayload->GetSize());
     ospfHeader.SetRouterId(routerId.Get());
     ospfHeader.SetArea(areaId);
     lsAckPayload->AddHeader(ospfHeader);

--- a/helper/ospf-packet-helper.h
+++ b/helper/ospf-packet-helper.h
@@ -151,6 +151,8 @@ ConstructLSUPacket(Ipv4Address routerId, uint32_t areaId, uint16_t seqNum,
     lsaHeader.SetType(LsaHeader::LsType::RouterLSAs);
     lsaHeader.SetLength(20 + packet->GetSize());
     lsaHeader.SetSeqNum(seqNum);
+    lsaHeader.SetLsId(routerId.Get());
+    lsaHeader.SetAdvertisingRouter(routerId.Get());
     packet->AddHeader(lsaHeader);
 
     // Add OSPF header
@@ -182,7 +184,9 @@ ConstructLSUPacket(Ipv4Address routerId, uint32_t areaId, uint16_t seqNum, uint1
     // Add LSA header
     LsaHeader lsaHeader;
     lsaHeader.SetType(LsaHeader::LsType::RouterLSAs);
-    lsaHeader.SetLength(routerLsas.size());
+    lsaHeader.SetLength(20 + packet->GetSize());
+    lsaHeader.SetLsId(routerId.Get());
+    lsaHeader.SetAdvertisingRouter(routerId.Get());
     packet->AddHeader(lsaHeader);
 
     // Add OSPF header

--- a/helper/ospf-packet-helper.h
+++ b/helper/ospf-packet-helper.h
@@ -149,7 +149,7 @@ ConstructLSUPacket(Ipv4Address routerId, uint32_t areaId, uint16_t seqNum,
     // Add LSA header
     LsaHeader lsaHeader;
     lsaHeader.SetType(LsaHeader::LsType::RouterLSAs);
-    lsaHeader.SetLength(1);
+    lsaHeader.SetLength(20 + packet->GetSize());
     lsaHeader.SetSeqNum(seqNum);
     packet->AddHeader(lsaHeader);
 

--- a/model/lsa-header.cc
+++ b/model/lsa-header.cc
@@ -118,6 +118,13 @@ LsaHeader::GetAdvertisingRouter (void) const
   return m_advertisingRouter;
 }
 
+// Get the unique key <LS Type, Link-State ID, Advertising Router>
+std::tuple<uint8_t, uint32_t, uint32_t>
+LsaHeader::GetKey()
+{
+  return std::make_tuple(m_type, m_lsId, m_advertisingRouter);
+}
+
 bool
 LsaHeader::IsChecksumOk (void) const
 {

--- a/model/lsa-header.h
+++ b/model/lsa-header.h
@@ -93,6 +93,8 @@ public:
   void SetAdvertisingRouter (uint32_t advertisingRouter);
   uint32_t GetAdvertisingRouter(void) const;
 
+  std::tuple<uint8_t, uint32_t, uint32_t> GetKey();
+
   void SetSeqNum (uint32_t seqNum);
   uint32_t GetSeqNum(void) const;
 

--- a/model/ospf-app.cc
+++ b/model/ospf-app.cc
@@ -153,11 +153,11 @@ OspfApp::StartApplication (void)
     // For Hello, both bind and listen to m_helloAddress
     auto helloSocket = Socket::CreateSocket (GetNode (), tid);
     InetSocketAddress helloSocketAddress(m_helloAddress);
-    if (helloSocket->Bind (anySocketAddress) == -1)
+    if (helloSocket->Bind (helloSocketAddress) == -1)
     {
       NS_FATAL_ERROR ("Failed to bind socket");
     }
-    helloSocket->Connect (anySocketAddress);
+    helloSocket->Connect (helloSocketAddress);
     helloSocket->SetAllowBroadcast (true);
     helloSocket->SetAttribute("Protocol", UintegerValue(89));
     helloSocket->BindToNetDevice(m_boundDevices.Get(i));
@@ -167,11 +167,11 @@ OspfApp::StartApplication (void)
     // For LSA, both bind and listen to m_lsaAddress
     auto lsaSocket = Socket::CreateSocket (GetNode (), tid);
     InetSocketAddress lsaSocketAddress(m_lsaAddress);
-    if (lsaSocket->Bind (anySocketAddress) == -1)
+    if (lsaSocket->Bind (lsaSocketAddress) == -1)
     {
       NS_FATAL_ERROR ("Failed to bind socket");
     }
-    lsaSocket->Connect (anySocketAddress);
+    lsaSocket->Connect (lsaSocketAddress);
     lsaSocket->SetAllowBroadcast (true);
     lsaSocket->SetAttribute("Protocol", UintegerValue(89));
     lsaSocket->SetIpTtl(1);

--- a/model/ospf-app.h
+++ b/model/ospf-app.h
@@ -107,8 +107,9 @@ private:
   virtual void ScheduleTransmitHello (Time dt);
   virtual void SendHello ();
   virtual void SendAck (uint32_t ifIndex, Ptr<Packet> ackPayload, Ipv4Address originRouterId);
-  virtual void FloodLSU (Ptr<Packet> p, uint32_t inputIfIndex);
-  virtual void LSUTimeout(Ptr<Packet> p);
+  virtual void FloodLSU (Ptr<Packet> lsuPacket, uint32_t inputIfIndex);
+  virtual void SendLSU(uint32_t ifIndex, Ptr<Packet> lsuPacket, uint32_t flags, Ipv4Address routerId, Ipv4Address toAddress);
+  virtual void LSUTimeout(uint32_t ifIndex, Ptr<Packet> lsuPacket, uint32_t flags, Ipv4Address routerId, Ipv4Address toAddress);
   virtual void HelloTimeout (Ptr<OspfInterface> ospfInterface, Ipv4Address remoteRouterId, Ipv4Address remoteIp);
 
   /**
@@ -126,15 +127,17 @@ private:
 
   void HandleRouterLSU (uint32_t ifIndex, OspfHeader ospfHeader, LsaHeader lsaHeader, Ptr<RouterLsa> routerLsa);
 
-  void HandleLSAck (uint32_t ifIndex, Ipv4Address remoteRouterId, uint16_t seqNum);
+  void HandleLSAck (uint32_t ifIndex, OspfHeader ospfHeader, std::vector<LsaHeader> lsaHeaders);
 
   void UpdateRouting ();
 
   void RefreshHelloTimeout(uint32_t ifIndex, Ptr<OspfInterface> ospfInterface, Ipv4Address remoteRouterId, Ipv4Address remoteIp);
 
-  void RefreshLsuTimer();
+  void AdjacencyUpdate();
 
+  Ptr<RouterLsa> GetRouterLsa();
   Ptr<RouterLsa> GetRouterLsa(uint32_t areaId);
+
   std::vector<uint32_t> GetAllNeighborRouterIds();
 
   uint16_t m_port; //!< Port on which we listen for incoming packets.
@@ -166,7 +169,8 @@ private:
   uint16_t m_ttl;
   Ptr<Ipv4StaticRouting> m_routing;
   std::vector<Ptr<OspfInterface> > m_ospfInterfaces;
-  EventId m_lsuTimeout;
+  // a map <neighbor's routerId, EventId> for each interface
+  std::vector<std::unordered_map<uint32_t, EventId> > m_lsuTimeouts; 
   EventId m_ackEvent;
   std::map<uint32_t, uint16_t> m_seqNumbers; 
   std::map<uint32_t, Ptr<RouterLsa> > m_routerLsdb; // adjacency list of [routerId] -> remoteRouterId

--- a/model/ospf-app.h
+++ b/model/ospf-app.h
@@ -107,9 +107,11 @@ private:
   virtual void ScheduleTransmitHello (Time dt);
   virtual void SendHello ();
   virtual void SendAck (uint32_t ifIndex, Ptr<Packet> ackPayload, Ipv4Address originRouterId);
-  virtual void FloodLSU (Ptr<Packet> lsuPacket, uint32_t inputIfIndex);
-  virtual void SendLSU(uint32_t ifIndex, Ptr<Packet> lsuPacket, uint32_t flags, Ipv4Address routerId, Ipv4Address toAddress);
-  virtual void LSUTimeout(uint32_t ifIndex, Ptr<Packet> lsuPacket, uint32_t flags, Ipv4Address routerId, Ipv4Address toAddress);
+  virtual void FloodLSU (uint32_t inputIfIndex, Ptr<Packet> lsuPacket, std::tuple<uint8_t, uint32_t, uint32_t> lsaKey);
+  virtual void SendLSU(uint32_t ifIndex, Ptr<Packet> lsuPacket, uint32_t flags,
+                      std::tuple<uint8_t, uint32_t, uint32_t> lsaKey, Ipv4Address toAddress);
+  virtual void LSUTimeout(uint32_t ifIndex, Ptr<Packet> lsuPacket, uint32_t flags,
+                      std::tuple<uint8_t, uint32_t, uint32_t> lsaKey, Ipv4Address toAddress);
   virtual void HelloTimeout (Ptr<OspfInterface> ospfInterface, Ipv4Address remoteRouterId, Ipv4Address remoteIp);
 
   /**
@@ -169,12 +171,11 @@ private:
   uint16_t m_ttl;
   Ptr<Ipv4StaticRouting> m_routing;
   std::vector<Ptr<OspfInterface> > m_ospfInterfaces;
-  // a map <neighbor's routerId, EventId> for each interface
-  std::vector<std::unordered_map<uint32_t, EventId> > m_lsuTimeouts; 
+  // a map <lsaKey, EventId> for each interface
+  std::map<std::tuple<uint8_t, uint32_t, uint32_t>, EventId> m_lsuTimeouts; 
   EventId m_ackEvent;
-  std::map<uint32_t, uint16_t> m_seqNumbers; 
+  std::map<std::tuple<uint8_t, uint32_t, uint32_t>, uint16_t> m_seqNumbers; 
   std::map<uint32_t, Ptr<RouterLsa> > m_routerLsdb; // adjacency list of [routerId] -> remoteRouterId
-  std::unordered_map<uint32_t, bool> m_acknowledges; // acknowledge based on interface index
 
   // Routing
 

--- a/model/ospf-app.h
+++ b/model/ospf-app.h
@@ -143,7 +143,7 @@ private:
   uint16_t m_port; //!< Port on which we listen for incoming packets.
   std::vector<Ptr<Socket>> m_sockets; //!< Unicast socket
   std::vector<Ptr<Socket>> m_helloSockets; //!< Hello multicast socket
-  std::vector<Ptr<Socket>> m_lsaSockets; //!< Hello multicast socket
+  std::vector<Ptr<Socket>> m_lsaSockets; //!< LSA multicast socket
   Address m_local; //!< local multicast address
 
   // For OSPF

--- a/model/ospf-header.cc
+++ b/model/ospf-header.cc
@@ -204,7 +204,7 @@ OspfHeader::Deserialize (Buffer::Iterator start)
 
   m_type = i.ReadU8 ();
   uint16_t size = i.ReadNtohU16 ();
-  m_payloadSize = size - m_headerSize;
+  m_payloadSize = size - 24;
   m_routerId = i.ReadNtohU32 ();
   m_area = i.ReadNtohU32 ();
   m_checksum = i.ReadNtohU16 ();

--- a/model/ospf-interface.cc
+++ b/model/ospf-interface.cc
@@ -193,6 +193,22 @@ OspfInterface::GetNeighborLinks(uint32_t areaId) {
   return links;
 }
 
+// Get a list of <neighbor's router ID, router's IP address>
+std::vector<std::pair<uint32_t, uint32_t> >
+OspfInterface::GetActiveNeighborLinks() {
+  std::vector<std::pair<uint32_t, uint32_t> > links;
+  auto neighbors = GetNeighbors();
+  // NS_LOG_INFO("# neighbors: " << neighbors.size());
+  for (auto n : neighbors) {
+    // Only aggregate neighbors that is at least in ExStart
+    // NS_LOG_INFO("  (" << n->GetRouterId().Get() << ", " << m_ipAddress.Get() << ")");
+    if (n->GetState() >= OspfNeighbor::ExStart) {
+      links.emplace_back(n->GetRouterId().Get(), m_ipAddress.Get());
+    }
+  }
+  return links;
+}
+
 // Get a list of <neighbor's router ID, router's IP address> that matches parameter's area
 std::vector<std::pair<uint32_t, uint32_t> >
 OspfInterface::GetActiveNeighborLinks(uint32_t areaId) {

--- a/model/ospf-interface.h
+++ b/model/ospf-interface.h
@@ -83,6 +83,7 @@ public:
   //  Vector of <neighbor's routerIds, its own interface ipAddress>
   std::vector<std::pair<uint32_t, uint32_t> > GetNeighborLinks();
   std::vector<std::pair<uint32_t, uint32_t> > GetNeighborLinks(uint32_t areaId);
+  std::vector<std::pair<uint32_t, uint32_t> > GetActiveNeighborLinks();
   std::vector<std::pair<uint32_t, uint32_t> > GetActiveNeighborLinks(uint32_t areaId);
 
 


### PR DESCRIPTION
- Now use LSA headers as keys to identify outstanding LSAs sent by Link State Update
- ACK is now working as intended, effectively stopping acked LSAs from sending 
- All packets are now clean and parse-able by Wireshark
- Fix many issues regarding acknowledgement and handling packets from sockets